### PR TITLE
Fix test_plugin_is_installed()

### DIFF
--- a/llm-{{cookiecutter.hyphenated}}/tests/test_{{cookiecutter.underscored}}.py
+++ b/llm-{{cookiecutter.hyphenated}}/tests/test_{{cookiecutter.underscored}}.py
@@ -1,6 +1,7 @@
-from llm.plugins import pm
+from llm.plugins import load_plugins, pm
 
 
 def test_plugin_is_installed():
+    load_plugins()
     names = [mod.__name__ for mod in pm.get_plugins()]
     assert "llm_{{ cookiecutter.underscored }}" in names


### PR DESCRIPTION
After the change in https://github.com/simonw/llm/issues/626, we must call load_plugins() before checking whether they are installed.