### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # llm-plugin cookiecutter template
 
 A cookiecutter template for creating new [llm plugins](https://llm.datasette.io/en/stable/plugins/index.html).
-`
+
 ## Installation
 
 You'll need to have [cookiecutter](https://cookiecutter.readthedocs.io/) installed. I recommend pipx for this:


### PR DESCRIPTION
I found a backquote

<img width="653" height="223" alt="image" src="https://github.com/user-attachments/assets/5a29c294-f8fb-4aaa-84f5-4c069c14b692" />

and it seems to be a typo.
So I send this pull request.